### PR TITLE
Fix caching for the Get endpoint

### DIFF
--- a/RunSlingServer/WebApi/Services/EndpointsServices/GetStreamingStatusHandler.cs
+++ b/RunSlingServer/WebApi/Services/EndpointsServices/GetStreamingStatusHandler.cs
@@ -13,6 +13,8 @@ namespace RunSlingServer.WebApi.Services.EndpointsServices
 
         private readonly ILogger _logger;
 
+        public const string SlingBoxNameParameterName = "slingBoxName";
+
         public GetStreamingStatusHandler(IFileSystemAccess fileSystemAccess, ILogger logger)
         {
             _fileSystemAccess = fileSystemAccess;
@@ -22,11 +24,10 @@ namespace RunSlingServer.WebApi.Services.EndpointsServices
 
         public async Task<string> GetStreamingStatus(HttpContext context)
         {
-            const string slingBoxNameParameterName = "slingBoxName";
 
-            if (!context.Request.Query.ContainsKey(slingBoxNameParameterName))
+            if (!context.Request.Query.ContainsKey(SlingBoxNameParameterName))
             {
-                const string errorMessage = $"WebApi Get: Missing '{slingBoxNameParameterName}' parameter";
+                const string errorMessage = $"WebApi Get: Missing '{SlingBoxNameParameterName}' parameter";
                 await HandleError(errorMessage);
 
                 return string.Empty;
@@ -41,7 +42,7 @@ namespace RunSlingServer.WebApi.Services.EndpointsServices
                 return string.Empty;
             }
 
-            var slingBoxesNames = context.Request.Query[slingBoxNameParameterName];
+            var slingBoxesNames = context.Request.Query[SlingBoxNameParameterName];
             var serializedBoxesStatusToJson = GetSlingBoxesStatusAsJson(serverStatus, slingBoxesNames);
             var ip = WebHelpers.GetClientIp(context.Request);
 

--- a/RunSlingServer/WebApi/Services/WebApiService.cs
+++ b/RunSlingServer/WebApi/Services/WebApiService.cs
@@ -144,9 +144,18 @@ namespace RunSlingServer.WebApi.Services
 
             services.AddOutputCache(options =>
             {
-                options.AddBasePolicy(policy => policy.Expire(TimeSpan.FromSeconds(1)));
-                options.AddPolicy("Expire1.5", builder =>
-                    builder.Expire(TimeSpan.FromSeconds(1.5)));
+                options.AddBasePolicy(policy => policy
+                    .Expire(TimeSpan.FromSeconds(1))
+                    .SetVaryByQuery(GetStreamingStatusHandler.SlingBoxNameParameterName));
+
+                options.AddPolicy("Expire1.5", builder => builder
+                    .Expire(TimeSpan.FromSeconds(1.5))
+                    .SetVaryByQuery(GetStreamingStatusHandler.SlingBoxNameParameterName));
+
+                options.AddPolicy("Expire20", builder => builder
+                    .Expire(TimeSpan.FromSeconds(20))
+                    .SetVaryByQuery(GetStreamingStatusHandler.SlingBoxNameParameterName));
+
             });
 
 
@@ -187,6 +196,7 @@ namespace RunSlingServer.WebApi.Services
                 logger.LogInformation($"Response {context.Response.StatusCode} returned for {context.Request.Path.Value}.");
             });
 
+            app.UseOutputCache();
 
             MapEndpoints(app);
         }


### PR DESCRIPTION
The output cache has been disabled last month in order to narrow down a bug.
Now it's back so requests for server streaming status will not require disk access 
Cache duration: 1.5 seconds